### PR TITLE
[AC-5303] changing url from which remotesyslog2 is pulled from

### DIFF
--- a/remote_syslog2/attributes/default.rb
+++ b/remote_syslog2/attributes/default.rb
@@ -13,7 +13,7 @@ default['remote_syslog2']['config'] = {
 # These attributes probably shouldn't be changed unless they specifically need to be
 default['remote_syslog2']['config_file'] = '/srv/www/mc/current/log_files.yml'
 default['remote_syslog2']['pid_dir'] = '/var/run'
-default['remote_syslog2']['install']['download_file'] = 'https://github.com/papertrail/remote_syslog2/releases/download/v0.13/remote_syslog_linux_386.tar.gz'
+default['remote_syslog2']['install']['download_file'] = 'https://s3.amazonaws.com/masschallenge-deployment/remote_syslog_linux_386.tar.gz'
 default['remote_syslog2']['install']['download_path'] = '/tmp/remote_syslog.tar.gz'
 default['remote_syslog2']['install']['extract_path'] = '/tmp'
 default['remote_syslog2']['install']['extracted_path'] = '/tmp/remote_syslog'


### PR DESCRIPTION
NOTE - The ticket for AC-5303 calls for making sure that the logs under /srv/www/mc/shared/var/log are being captured. As it turns out, these are already configured in the papertrail yml file. The actual failure in log capture happens due to remote_syslog2 not being installed on our opsworks stacks. They were removed due to a failure in the custom recipe that installs remote_syslog2 which is what this PR resolves.

This fixes the "remote_syslog2" package which is required for papertrail based logging on opsworks servers. The current recipe on master fails due to an issue with permissions to the github resource from which the package is downloaded from: https://forums.aws.amazon.com/thread.jspa?messageID=677739

To test this:

1 - Go to a test opsworks stack and go to the "stack settings" make sure the branch/revision for the custom cookbooks is set to the current master.
<img width="786" alt="screen shot 2018-03-27 at 3 37 58 pm" src="https://user-images.githubusercontent.com/196425/37991686-d1d18782-31d7-11e8-92bb-016982803d27.png">

2 - run the "update custom cookbooks" command on the stack to make sure it has the latest master recipes.

3 - edit the "deploy" recipes and add the "remote_syslog2::default" recipe - make sure it comes before the opsworks_deploy_python recipe.

<img width="929" alt="screen shot 2018-03-30 at 11 54 12 am" src="https://user-images.githubusercontent.com/196425/38144043-31fd2770-3411-11e8-99cb-8b61e581c090.png">

4 -  run a deploy.

5 - note that this fails.

6 - go back to the stack settings and switch the branch (of the custom chef recipes) to AC-5303.

7 - go through steps 2-4 again

8 - note that this succeeds.

9 - ssh into the instance and run 'remote_syslog2" to confirm that it has been installed.

Once this gets merged in we will need to add the remote_syslog2::default recipe to all the stacks just before the opsworks deploy recipe.


