### PR TITLE
[AC-5784] add recipe to run command to check algolia index schema and reindex

### DIFF
--- a/opsworks_deploy_python/metadata.rb
+++ b/opsworks_deploy_python/metadata.rb
@@ -20,4 +20,5 @@ recipe "opsworks_deploy_python", "Install and setup a python application in a vi
 recipe "opsworks_deploy_python::buildout", "Install and setup a buildout based python application"
 recipe "opsworks_deploy_python::django", "Install and setup a django based python application"
 recipe "opsworks_deploy_python::r3-mount-patch", "Patch to mount /mnt filesystems for r3 instances"
+recipe "opsworks_deploy_python::reindex-algolia", "reindex algolia on deploy"
 recipe "opsworks_deploy_python::symlink-volume", "create a symlink from our deploy dir to a large volume"

--- a/opsworks_deploy_python/recipes/reindex-algolia.rb
+++ b/opsworks_deploy_python/recipes/reindex-algolia.rb
@@ -1,0 +1,11 @@
+require 'chef/log'
+Chef::Log.level = :debug
+script "mount_volume" do
+  interpreter "bash"
+  user "root"
+  cwd "/home/deploy"
+  environment node['deploy']['mc']['environment']
+  code <<-EOH
+    /srv/www/mc/current/bin/django check_algolia_index_schema
+  EOH
+end


### PR DESCRIPTION
#### Changes introduced:
- Add a recipe to run the custom `check_algolia_index_schema` command on deploy which would check if the algolia index schema has changed and trigger a reindex