### PR TITLE
AC-6120: ECS Deployments expect a hardcoded service called "impact"

### DIFF
--- a/impact_deploy/recipes/default.rb
+++ b/impact_deploy/recipes/default.rb
@@ -2,6 +2,7 @@ require 'chef/log'
 Chef::Log.level = :debug
 revision = node["deploy"]["mc"]["scm"]["revision"]
 impact_environment = node['deploy']['mc']['environment']['IMPACT_ENVIRONMENT']
+impact_service = node['deploy']['mc']['environment']['IMPACT_SERVICE']
 docker_registry = node['deploy']['mc']['environment']['DOCKER_REGISTRY']
 ecs_secret_access_key = node['deploy']['mc']['environment']['ECS_SECRET_ACCESS_KEY']
 ecs_access_key_id = node['deploy']['mc']['environment']['ECS_ACCESS_KEY_ID']
@@ -15,6 +16,7 @@ script "set_release" do
     # trigger a deploy of impact-api
     export DEPLOY_TARGET=#{revision}
     export IMPACT_ENVIRONMENT=#{impact_environment}
+    export IMPACT_SERVICE=#{impact_service}
     export DOCKER_REGISTRY=#{docker_registry}
     export AWS_DEFAULT_REGION=#{ecs_default_region}
     export DOCKER_REGISTRY=#{docker_registry}
@@ -26,7 +28,7 @@ script "set_release" do
         virtualenv --no-site-packages .venv && source .venv/bin/activate
         pip install --upgrade certifi pyopenssl requests[security] ndg-httpsclient pyasn1 pip
         pip install ecs-deploy
-        .venv/local/bin/ecs deploy --ignore-warnings $IMPACT_ENVIRONMENT impact --image web $DOCKER_REGISTRY/impact-api:$DEPLOY_TARGET --image redis $DOCKER_REGISTRY/redis:$DEPLOY_TARGET --access-key-id $ECS_ACCESS_KEY_ID --secret-access-key $ECS_SECRET_ACCESS_KEY --region $AWS_DEFAULT_REGION --timeout 600
+        .venv/local/bin/ecs deploy --ignore-warnings $IMPACT_ENVIRONMENT $IMPACT_SERVICE --image web $DOCKER_REGISTRY/impact-api:$DEPLOY_TARGET --image redis $DOCKER_REGISTRY/redis:$DEPLOY_TARGET --access-key-id $ECS_ACCESS_KEY_ID --secret-access-key $ECS_SECRET_ACCESS_KEY --region $AWS_DEFAULT_REGION --timeout 600
         rm -rf .venv/
      fi
   EOH


### PR DESCRIPTION
**Changes introduced in AC-6120**:
- use of an environment variable to determine the name of the ecs cluster service to deploy to

**How to test**:
- the test 2 cluster was recently created and the service name is `impact-test-2`
- under the current scheme, deployments in ECS will not be successful i.e. the images deployed in the service won't be updated

To be the hero and make the deployments work, follow the following steps
- visit the test 2 [stack settings ](https://console.aws.amazon.com/opsworks/home?region=us-east-1#/stack/be1aff02-9fb5-4c7c-9241-d515f8f5f816/show) on opsworks and change the `Branch/Revision` of the opsworks repo to `AC-6120`
- ensure the `IMPACT_SERVICE` env variable is `impact-test-2` (the name of the test 2 impact service) and `Save`
- select `Update custom cookbooks` from the [`deployments` tab](https://console.aws.amazon.com/opsworks/home?region=us-east-1#/stack/be1aff02-9fb5-4c7c-9241-d515f8f5f816/deployments/deploy-stack) and hit the `Update custom cookbooks` button
- Once that is green, deploy a recent tag to the test2 stack e.g. `v1.0.57`
- Once this is done, if you navigate to the [test 2 ECS stack tasks](https://console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/test2/services/impact-test-2/tasks)
- Click the link under the `Task` column
- Under `Containers`, expand the `Image` column and notice that the tag you deployed is part of the text under `Image`

![screen shot 2018-10-26 at 20 24 21](https://user-images.githubusercontent.com/9318050/47582617-8583e680-d95d-11e8-9c52-c52c24f1319b.png)
