### PR TITLE
[AC-6178] added 'future' package for use by bootstrap.py

### DIFF
--- a/opsworks_deploy_python/attributes/default.rb
+++ b/opsworks_deploy_python/attributes/default.rb
@@ -6,6 +6,6 @@ node.default["deploy_python"]["custom_type"] = "python"
 node.default["deploy_python"]["symlink_before_migrate"] = {}
 node.default["deploy_python"]["purge_before_symlink"] = []
 node.default["deploy_python"]["create_dirs_before_symlink"] = ['public', 'tmp']
-node.default["deploy_python"]["packages"] = []
+node.default["deploy_python"]["packages"] = ['future']
 node.default["deploy_python"]["os_packages"] = []
 node.default["deploy_python"]["venv_options"] = '--no-site-packages'


### PR DESCRIPTION
This is blocking deploy of v1.0.109.

**Details:** The `future` package is needed by `bootstrap.py`, which runs _before_ buildout proper and so does not pick it up from the [buildout requirements](https://github.com/masschallenge/accelerate/blob/8882364167/cfg/locked_versions.cfg#L26).