### PR TITLE
AC-7198: send deploy logs to papertrail

### DIFF
--- a/opsworks_deploy_python/recipes/logging-permissions.rb
+++ b/opsworks_deploy_python/recipes/logging-permissions.rb
@@ -6,6 +6,6 @@ script "set_permissions" do
   cwd "/home/deploy"
   code <<-EOC
     echo "set permissions for logging"
-    sudo find /var/lib/aws/opsworks/chef/ -name "*.log" | xargs sudo chmod 555
+    sudo find /var/lib/aws/opsworks/chef/ -name "*.log" | xargs sudo chmod 644
   EOC
 end

--- a/opsworks_deploy_python/recipes/logging-permissions.rb
+++ b/opsworks_deploy_python/recipes/logging-permissions.rb
@@ -1,0 +1,12 @@
+require 'chef/log'
+Chef::Log.level = :debug
+script "set_permissions" do
+  interpreter "bash"
+  user "root"
+  cwd "/home/deploy"
+  code <<-EOC
+    echo "set permissions for logging"
+    echo "set permissions for logging" >> set-perms.txt
+    sudo find /var/lib/aws/opsworks/chef/ -name "*.log" | xargs sudo chmod 777
+  EOC
+end

--- a/opsworks_deploy_python/recipes/logging-permissions.rb
+++ b/opsworks_deploy_python/recipes/logging-permissions.rb
@@ -6,6 +6,6 @@ script "set_permissions" do
   cwd "/home/deploy"
   code <<-EOC
     echo "set permissions for logging"
-    sudo find /var/lib/aws/opsworks/chef/ -name "*.log" | xargs sudo chmod 644
+    sudo find /var/lib/aws/opsworks/chef/ -name "*.log" | xargs sudo chmod 555
   EOC
 end

--- a/opsworks_deploy_python/recipes/logging-permissions.rb
+++ b/opsworks_deploy_python/recipes/logging-permissions.rb
@@ -6,7 +6,6 @@ script "set_permissions" do
   cwd "/home/deploy"
   code <<-EOC
     echo "set permissions for logging"
-    echo "set permissions for logging" >> set-perms.txt
-    sudo find /var/lib/aws/opsworks/chef/ -name "*.log" | xargs sudo chmod 777
+    sudo find /var/lib/aws/opsworks/chef/ -name "*.log" | xargs sudo chmod 555
   EOC
 end

--- a/opsworks_deploy_python/recipes/logging-permissions.rb
+++ b/opsworks_deploy_python/recipes/logging-permissions.rb
@@ -6,6 +6,7 @@ script "set_permissions" do
   cwd "/home/deploy"
   code <<-EOC
     echo "set permissions for logging"
-    sudo find /var/lib/aws/opsworks/chef/ -name "*.log" | xargs sudo chmod 555
+    echo "set permissions for logging" >> set-perms.txt
+    sudo find /var/lib/aws/opsworks/chef/ -name "*.log" | xargs sudo chmod 777
   EOC
 end


### PR DESCRIPTION
This PR adds a recipe that is responsible for setting permissions on the log directory so remote_syslog can access the log files.

see [associated PR](https://github.com/masschallenge/accelerate/pull/2553) for details