### PR TITLE
adding fix for impact deploy

### DIFF
--- a/impact_deploy/recipes/default.rb
+++ b/impact_deploy/recipes/default.rb
@@ -9,11 +9,13 @@ ecs_access_key_id = node['deploy']['mc']['environment']['ECS_ACCESS_KEY_ID']
 ecs_default_region = node['deploy']['mc']['environment']['AWS_DEFAULT_REGION']
 script "set_release" do
   interpreter "bash"
-  user "deploy"
+  user "root"
   cwd "/home/deploy"
   environment node['deploy']['mc']['environment']
   code <<-EOH
     # trigger a deploy of impact-api
+    export LC_ALL=C.UTF-8
+    export LANG=C.UTF-8
     export DEPLOY_TARGET=#{revision}
     export IMPACT_ENVIRONMENT=#{impact_environment}
     export IMPACT_SERVICE=#{impact_service}

--- a/impact_deploy/recipes/default.rb
+++ b/impact_deploy/recipes/default.rb
@@ -28,7 +28,7 @@ script "set_release" do
         virtualenv .venv && source .venv/bin/activate
         pip install --upgrade certifi pyopenssl requests[security] ndg-httpsclient pyasn1 pip
         pip install ecs-deploy
-        .venv/local/bin/ecs deploy --ignore-warnings $IMPACT_ENVIRONMENT $IMPACT_SERVICE --image web $DOCKER_REGISTRY/impact-api:$DEPLOY_TARGET --image redis $DOCKER_REGISTRY/redis:$DEPLOY_TARGET --access-key-id $ECS_ACCESS_KEY_ID --secret-access-key $ECS_SECRET_ACCESS_KEY --region $AWS_DEFAULT_REGION --timeout 600
+        .venv/bin/ecs deploy --ignore-warnings $IMPACT_ENVIRONMENT $IMPACT_SERVICE --image web $DOCKER_REGISTRY/impact-api:$DEPLOY_TARGET --image redis $DOCKER_REGISTRY/redis:$DEPLOY_TARGET --access-key-id $ECS_ACCESS_KEY_ID --secret-access-key $ECS_SECRET_ACCESS_KEY --region $AWS_DEFAULT_REGION --timeout 600
         rm -rf .venv/
      fi
   EOH


### PR DESCRIPTION
This PR fixes impact api deploys.

To test:

1 - find a stack to deploy to
2 - go to the ECS cluster associated with the stack and look at the task definition (note the number) it is assigned.
<img width="772" alt="Screen Shot 2020-04-23 at 10 18 39 AM" src="https://user-images.githubusercontent.com/196425/80109837-00768f00-854c-11ea-87bd-6da19fda754d.png">

3 - run a deploy of this branch to the stack
4 - go back to the ECS cluster and note that the task definition number has changed.