### PR TITLE
[AC-7760] P0: Restrict alternatives cookbook version

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -28,6 +28,7 @@ cookbook 'runit', '1.5.10'
 cookbook 'rsyslog', '1.12.2'
 cookbook 'newrelic', '2.3.0'
 cookbook 'newrelic_plugins', '1.1.0'
+cookbook 'alternatives', github: 'vkhatri/chef-alternatives',  tag: "v0.2.0"
 
 # Uncomment the items below for testing deployments with Vagrant
 


### PR DESCRIPTION
### Changes introduced in: [AC-7760](https://masschallenge.atlassian.net/browse/AC-7760):
- limits alternatives cookbook version

### How to test
- In stack settings for "Use custom Chef cookbooks", set "Branch/Revision" to **AC-7760**
- From your instance, click "Run Command" and choose  "Upate custom cookbooks".
- After that completes, run command "Setup".
- Confirm that setup ended in success (green checkmark) instead of failure (red exclamation mark).