### PR TITLE
[AC-8338] :: P1: Supervisor fails on new instances

### DIFF
--- a/opsworks_deploy_python/templates/default/supervisor_upstart.erb
+++ b/opsworks_deploy_python/templates/default/supervisor_upstart.erb
@@ -8,7 +8,7 @@ setuid <%= @user %>
 setgid <%= @group %>
 <% if @environment %>
 <% @environment.each do |key,val| %>
-<% if key.match(/\s/) %>
+<% if val.match(/\s/) %>
 env <%= key %>=<%= "\"#{val}\"" %>
 <% else %>
 env <%= key %>=<%= val %>

--- a/opsworks_deploy_python/templates/default/supervisor_upstart.erb
+++ b/opsworks_deploy_python/templates/default/supervisor_upstart.erb
@@ -8,11 +8,7 @@ setuid <%= @user %>
 setgid <%= @group %>
 <% if @environment %>
 <% @environment.each do |key,val| %>
-<% if val =~ /\s/ %>
 env <%= key %>=<%= "\"#{val}\"" %>
-<% else %>
-env <%= key %>=<%= val %>
-<% end %>
 <% end %>
 <% end %>
 

--- a/opsworks_deploy_python/templates/default/supervisor_upstart.erb
+++ b/opsworks_deploy_python/templates/default/supervisor_upstart.erb
@@ -8,7 +8,11 @@ setuid <%= @user %>
 setgid <%= @group %>
 <% if @environment %>
 <% @environment.each do |key,val| %>
+<% if key.match(/\s/) %>
+env <%= key %>=<%= "\"#{val}\"" %>
+<% else %>
 env <%= key %>=<%= val %>
+<% end %>
 <% end %>
 <% end %>
 

--- a/opsworks_deploy_python/templates/default/supervisor_upstart.erb
+++ b/opsworks_deploy_python/templates/default/supervisor_upstart.erb
@@ -8,7 +8,7 @@ setuid <%= @user %>
 setgid <%= @group %>
 <% if @environment %>
 <% @environment.each do |key,val| %>
-<% if val.match(/\s/) %>
+<% if val =~ /\s/ %>
 env <%= key %>=<%= "\"#{val}\"" %>
 <% else %>
 env <%= key %>=<%= val %>


### PR DESCRIPTION
### Changes introduced in: [AC-8338](https://masschallenge.atlassian.net/browse/AC-8338):
- Adds quotes to environment variables with spaces in the supervisor.conf file

### How to test
- create a stack using `AC-8297` on infrastructure
  - The instance will fail
- In stack settings, update `Branch/Revision` to `AC-8338`
- Spin up a new instance in the stack, it should build successfully